### PR TITLE
Replaced tradesatoshi.com with cratex.io

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -145,7 +145,7 @@
                                 </div>
                                 <div class="swiper-slide">
                                     <div class="image-container">
-                                        <a href="https://tradesatoshi.com/Exchange?market=YTN_BTC" target="_blank"><b>TRADESATOSHI.COM</b></a>
+                                        <a href="https://cratex.io/index.php?pair=YTN/DOGE" target="_blank"><b>CRATEX.IO</b></a>
                                     </div>
                                 </div>
                                 <div class="swiper-slide">


### PR DESCRIPTION
Replaced tradesatoshi.com with cratex.io
Ok, second try. Looks like the site is on yenten-3.x.x branch.