### PR TITLE
Fix build error when using Qt 5.15

### DIFF
--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -7,6 +7,7 @@
 
 #include <QWidget>
 #include <QQueue>
+#include <QPainterPath>
 
 class ClientModel;
 


### PR DESCRIPTION
When using Qt 5.15, build fails with the following error:
`qt/trafficgraphwidget.cpp:54:9: エラー: invalid use of incomplete type ‘class QPainterPath’`
which can be fixed by adding `#include <QPainterPath>`.

Same problem is discussed here:
https://github.com/qgis/QGIS/issues/37005